### PR TITLE
Chartboost SDK 8.2.0

### DIFF
--- a/Objective-C/ChartboostExample/AppDelegate.m
+++ b/Objective-C/ChartboostExample/AppDelegate.m
@@ -15,8 +15,11 @@
 {
     NSLog(@"Chartboost SDK Version %@", [Chartboost getSDKVersion]);
   
-    [Chartboost setPIDataUseConsent:YesBehavioral];
+    [Chartboost addDataUseConsent:[CHBGDPRDataUseConsent gdprConsent:CHBGDPRConsentBehavioral]];
+    [Chartboost addDataUseConsent:[CHBCCPADataUseConsent ccpaConsent:CHBCCPAConsentOptInSale]];
+    
     [Chartboost setLoggingLevel:CBLoggingLevelInfo];
+    
     [Chartboost startWithAppId:@"4f21c409cd1cb2fb7000001b"
                   appSignature:@"92e2de2fd7070327bdeb54c15a5295309c6fcd2d"
                     completion:^(BOOL success) {

--- a/Objective-C/ChartboostExample/ViewController.m
+++ b/Objective-C/ChartboostExample/ViewController.m
@@ -82,7 +82,7 @@
     }
 }
 
-// MARK: - CHBAdDelegate
+// MARK: - Ad Delegate (Interstitial, Rewarded & Banner)
 
 - (void)didCacheAd:(CHBCacheEvent *)event error:(nullable CHBCacheError *)error {
     [self log:[NSString stringWithFormat:@"didCacheAd: %@ %@", [event.ad class], [self statusWithError:error]]];
@@ -114,13 +114,13 @@
     return error ? [NSString stringWithFormat:@"FAILED (%@)", error] : @"SUCCESS";
 }
 
-// MARK: - CHBInterstitialDelegate
+// MARK: - Ad Delegate (Interstitial & Rewarded)
 
 - (void)didDismissAd:(CHBDismissEvent *)event {
     [self log:[NSString stringWithFormat:@"didDismissAd: %@", [event.ad class]]];
 }
 
-// MARK: - CHBRewardedDelegate
+// MARK: - Ad Delegate (Rewarded)
 
 - (void)didEarnReward:(CHBRewardEvent *)event {
     [self log:[NSString stringWithFormat:@"didEarnReward: %ld", (long)event.reward]];

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Chartboost SDK for iOS
 
-*Version 8.1.0*
+*Version 8.2.0*
 
 The Chartboost iOS SDK is the cornerstone of the Chartboost network. It
 provides the functionality for showing interstitial, rewarded and banner ads.


### PR DESCRIPTION
Updated example app to use new consent APIs in SDK 8.2.0.
Updated comments to make clearer to which type of ad each delegate method corresponds to