### PR TITLE
feat: add secrets scanning workflow

### DIFF
--- a/.github/workflows/loopme-secrets-scan.yml
+++ b/.github/workflows/loopme-secrets-scan.yml
@@ -1,0 +1,29 @@
+# ============================================================
+# Secrets Scan — managed by loopme/secrets
+# DO NOT edit scanning logic here. To update rules or
+# add exclusions, see: https://github.com/loopme/secrets/blob/main/docs/adding-exclusions.md
+# ============================================================
+name: Loopme Secrets Scanning
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+      - develop
+  workflow_dispatch:
+
+jobs:
+  scan:
+    uses: loopme/secrets/.github/workflows/loopme-secrets-scan.yml@main
+    secrets:
+      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+      SECRETS_SCAN_APP_ID_GITHUB: ${{ secrets.SECRETS_SCAN_APP_ID_GITHUB }}
+      SECRETS_SCAN_APP_PRIVATE_KEY_GITHUB: ${{ secrets.SECRETS_SCAN_APP_PRIVATE_KEY_GITHUB }}
+    # Optional inputs — uncomment to customise:
+    # with:
+    #   config-file: .gitleaks.toml          # path to repo-local config (default: .gitleaks.toml)
+    #   notify-user-list: "@user1,@user2"    # GitHub users to @-mention in PR comments
+    #   extra-arguments: "--verbose"          # any extra gitleaks flags
+    #   enable-comments: true                 # set to false to suppress inline PR comments (check still fails)

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,13 @@
+# Default repository-local gitleaks configuration.
+# This file is used automatically when a repo has no .gitleaks.toml.
+# Copy it to your repo root as .gitleaks.toml and add your exclusions.
+# See: https://github.com/loopme/secrets/blob/main/docs/adding-exclusions.md
+
+# Use all built-in gitleaks default rules
+[extend]
+  useDefault = true
+
+[allowlist]
+  description = "global allowlist"
+  regexes = []
+  paths = []


### PR DESCRIPTION
Improving security is one of our company's goals this year. With Engineering & Devops & InfoSec combined efforts we came up with a solution that combines global scanning and reporting with a way for teams to easily get early feedback and overall visibility

## How it works:
- **PR Guardrails:** A gitleaks scanner runs as a GitHub Action on every PR - it only scans the PR diff, so it's fast and won't slow you down
- **Main Branch Scans:** Full scans run on merges to main and on-demand to ensure the existing codebase remains clean.
- **Global Reporting:** A weekly scan of all LM/CB repositories will generate a global report. You can expect to see these reports starting next week.

This has been running on my team's repos without any issues. Please ping me if you are interested in early adoption.

## Next steps:
- This PR is part of roll up to active repositories.
- The Pull Requests scanner will help you identify new issues, however, this should be a very rare case
- Please plan actions on existing secrets. In some cases, the scanner will find false positives, just add them to ignore file. Claude Code prompt "Validate, fix or ignore gitleaks finds + <output of github action job>" works like a charm.
- Please note - our goal isn't to fix everything overnight, but to stop the "leak" and make steady progress on existing debt

Full details, examples, and troubleshooting: https://loopme.atlassian.net/wiki/spaces/OPS/pages/4401332317/Secrets+scanning+in+CI+CD

For any questions / feedback, please join #tmp-scanner-rollout
